### PR TITLE
Removed extra rows 

### DIFF
--- a/MainFrame.py
+++ b/MainFrame.py
@@ -148,6 +148,9 @@ class MainFrame (wx.Frame):
         self.dictionary = dict(Counter(words))
         self.dictionary = self.sortDictionary(self.dictionary)
 
+        if (self.dataView.GetNumberRows() > 0):
+            self.dataView.DeleteRows(numRows=self.dataView.GetNumberRows())
+
         for i,value in enumerate(self.dictionary):
             self.dataView.InsertRows(pos=i)
             self.dataView.SetCellValue(i,0,value[1])


### PR DESCRIPTION
I observed an issue due to which if I press 'Contar' button twice (or multiple times) using the same (or different) file, the grid (on right side) shows data starting from 1st row but many empty rows gets appended at the end of grid.

Steps to reproduce:
1) Select a file (using Browse) and press Contar to get word count
2) a) Re-press Contar and observe many rows appended at the end of grid
OR 
   b) Change the file and press Contar. There will be many rows at the end of grid

The reason of such behavior is that ClearGrid() function only clears data and does not destroy (or delete) the rows.
The fix is to manually destroy all the rows and then add new rows.

#hacktoberfest
